### PR TITLE
Rename return variable to use the correct rate

### DIFF
--- a/src/Model/Import.php
+++ b/src/Model/Import.php
@@ -75,7 +75,7 @@ class Import extends \Magento\Directory\Model\Currency\Import\AbstractImport
                 return bcadd($rate, '0', 12);
             }
 
-            return (double)$xml;
+            return (double) $rate;
         } catch (\Exception $e) {
             if ($retry == 0) {
                 $this->_convert($currencyFrom, $currencyTo, 1);


### PR DESCRIPTION
If `bcadd` doesn't exist then the rate is never returned only an undefined `$xml` variable.
